### PR TITLE
Add basic authentication service and routes

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,10 @@
 from fastapi import FastAPI
+
+from .routes.auth import router as auth_router
+
+
 app = FastAPI()
+app.include_router(auth_router)
 
 @app.get("/")
 def read_root():

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -1,0 +1,27 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from ..models import get_session
+from ..schemas import UserCreate, UserLogin
+from ..services.auth import AuthService, AuthenticationError
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+service = AuthService()
+
+
+@router.post("/register")
+def register(user: UserCreate, db: Session = Depends(get_session)):
+    try:
+        created = service.create_user(db, user.email, user.password)
+        return {"id": created.id, "email": created.email}
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+
+@router.post("/login")
+def login(credentials: UserLogin, db: Session = Depends(get_session)):
+    try:
+        user = service.authenticate_user(db, credentials.email, credentials.password)
+        return {"message": "Login successful", "user_id": user.id}
+    except AuthenticationError:
+        raise HTTPException(status_code=401, detail="Invalid credentials")

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,1 +1,11 @@
-# Pydantic schemas placeholder
+from pydantic import BaseModel, EmailStr
+
+
+class UserCreate(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class UserLogin(BaseModel):
+    email: EmailStr
+    password: str

--- a/app/services/auth.py
+++ b/app/services/auth.py
@@ -1,0 +1,53 @@
+import hashlib
+import hmac
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from ..models import User
+
+
+class AuthenticationError(Exception):
+    """Raised when authentication fails."""
+
+
+@dataclass
+class AuthService:
+    """Service handling user authentication and creation."""
+
+    def _hash_password(self, password: str, salt: Optional[bytes] = None) -> str:
+        """Hash a password with PBKDF2."""
+        if salt is None:
+            salt = os.urandom(16)
+        hashed = hashlib.pbkdf2_hmac("sha256", password.encode(), salt, 100000)
+        return f"{salt.hex()}:{hashed.hex()}"
+
+    def _verify_password(self, password: str, stored_hash: str) -> bool:
+        """Verify a password against the stored hash."""
+        try:
+            salt_hex, hash_hex = stored_hash.split(":")
+        except ValueError as exc:
+            raise AuthenticationError("Invalid stored password format") from exc
+        salt = bytes.fromhex(salt_hex)
+        hashed = hashlib.pbkdf2_hmac("sha256", password.encode(), salt, 100000)
+        return hmac.compare_digest(hashed.hex(), hash_hex)
+
+    def create_user(self, db: Session, email: str, password: str) -> User:
+        """Create a new user with a hashed password."""
+        if db.query(User).filter(User.email == email).first() is not None:
+            raise ValueError("Email already registered")
+        hashed_password = self._hash_password(password)
+        user = User(email=email, hashed_password=hashed_password)
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+        return user
+
+    def authenticate_user(self, db: Session, email: str, password: str) -> User:
+        """Authenticate a user with the provided credentials."""
+        user = db.query(User).filter(User.email == email).first()
+        if user is None or not self._verify_password(password, user.hashed_password):
+            raise AuthenticationError("Invalid credentials")
+        return user


### PR DESCRIPTION
## Summary
- add Pydantic schemas for user auth
- implement AuthService with hashed password handling
- expose register and login endpoints and wire into FastAPI app

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af3f0f0840832a8277e86f498f45f0